### PR TITLE
Fix patch to self hosted cors utility

### DIFF
--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -57,7 +57,7 @@ function parseURLParams() {
 }
 
 function fixURL(url) {
-    return 'https://cors-anywhere.herokuapp.com/' + url;
+    return 'http://unrestricted-lorefare-cors.duckdns.org:8080/' + url;
 }
 
 function fetchURLs(url) {


### PR DESCRIPTION
Change patch URL to a self-hosted cors redirect service which doesn't rate-limit but whitelists swnmap.com